### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/parser/main.py
+++ b/parser/main.py
@@ -28,13 +28,13 @@ def main():
     start, stop = sys.argv[1], sys.argv[2]
 
   except IndexError:
-    logger.error( '%s start stop'%sys.argv[0] ) 
+    logger.error( '{0!s} start stop'.format(sys.argv[0]) ) 
     sys.exit(-1)
 
 
   logger.info("Scaper Start")
   [ job_queue.put(product_base_url+str(i)+suffix)  for i in xrange(int(start),int(stop))]
-  logger.info("Got %d products in queue"%job_queue.qsize())
+  logger.info("Got {0:d} products in queue".format(job_queue.qsize()))
   threads = [threading.Thread(target=hansa_worker) for x in xrange(thread_pool_size)]
   for thread in threads:
       thread.start()
@@ -76,7 +76,7 @@ def hansa_worker():
       job_done=True
 
     except Exception, e: 
-      logger.error("Exception in thread, url :%s "%url)
+      logger.error("Exception in thread, url :{0!s} ".format(url))
       traceback.print_exc()
       #print html
       #job_done=True


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:alx:Hansa_scrape?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:alx:Hansa_scrape?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)